### PR TITLE
fix path to `settings.json`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains the `channel.json` file which lists all micro plugins. 
 
 ## Settings
 
-Add this repository in ~/.config/settings.json
+Add this repository in `~/.config/micro/settings.json`
 ```json
 "pluginchannels": [
     "https://raw.githubusercontent.com/micro-editor/plugin-channel/master/channel.json",


### PR DESCRIPTION
This corrects the path to the `settings.json` to `~/.config/micro/settings.json`.